### PR TITLE
1 allows drawing of lines

### DIFF
--- a/bly-ac/src/lib.rs
+++ b/bly-ac/src/lib.rs
@@ -15,4 +15,6 @@ pub trait Backend {
     // Primitives
     /// Draws a rectangle
     unsafe fn draw_rect(&mut self, x: f32, y: f32, width: f32, height: f32, r: f32, g: f32, b: f32, a: f32);
+
+    unsafe fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, r: f32, g: f32, b: f32, a: f32);
 }

--- a/bly-cairo/src/lib.rs
+++ b/bly-cairo/src/lib.rs
@@ -87,18 +87,13 @@ impl Backend for CairoBackend {
 
     unsafe fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, r: f32, g: f32, b: f32, a: f32) {
         let (width,height) = util::get_xlib_window_size(self.display,self.handle);
-        let xc = width / 2;
-        let yc = height / 2;
 
-        cairo_set_line_width(self.cairo,10.0);
+        cairo_set_line_width(self.cairo,stroke as c_double);
 
-        // draw red lines out from the center of the window
         cairo_set_source_rgba(self.cairo, r as c_double, g as c_double, b as c_double,a as c_double);
-        cairo_move_to(self.cairo,0.0, 0.0);
-        cairo_line_to(self.cairo, xc as c_double, yc as c_double);
-        cairo_line_to(self.cairo, 0.0, height as c_double);
-        cairo_move_to(self.cairo, xc as c_double, yc as c_double);
-        cairo_line_to(self.cairo, width as c_double, yc as c_double);
+        cairo_move_to(self.cairo,x1 as c_double, y1 as c_double);
+        cairo_line_to(self.cairo, x2 as c_double, y2 as c_double);
+    
         cairo_stroke(self.cairo);
     }
 }

--- a/bly-cairo/src/lib.rs
+++ b/bly-cairo/src/lib.rs
@@ -3,11 +3,7 @@
 mod util;
 
 use bly_ac::Backend;
-use cairo::ffi::{
-    cairo_create, cairo_destroy, cairo_fill, cairo_image_surface_create, cairo_rectangle,
-    cairo_scale, cairo_set_source_rgb, cairo_surface_create_similar, cairo_surface_t, cairo_t,
-    cairo_xlib_surface_create,
-};
+use cairo::ffi::{cairo_create, cairo_destroy, cairo_fill, cairo_image_surface_create, cairo_line_to, cairo_move_to, cairo_rectangle, cairo_scale, cairo_set_line_width, cairo_set_source_rgb, cairo_set_source_rgba, cairo_stroke, cairo_surface_create_similar, cairo_surface_t, cairo_t, cairo_xlib_surface_create};
 use cairo::Surface;
 use std::ffi::{c_double, c_int, c_ulong};
 use x11::xlib::{Display, XDefaultVisual, XFlush, XGetGeometry, XOpenDisplay};
@@ -78,7 +74,7 @@ impl Backend for CairoBackend {
     }
 
     unsafe fn draw_rect(&mut self, x: f32, y: f32, width: f32, height: f32, r: f32, g: f32, b: f32, a: f32) {
-        cairo_set_source_rgb(self.cairo, r as c_double, g as c_double, b as c_double);
+        cairo_set_source_rgba(self.cairo, r as c_double, g as c_double, b as c_double,a as c_double);
         cairo_rectangle(
             self.cairo,
             x as c_double,
@@ -87,6 +83,23 @@ impl Backend for CairoBackend {
             height as c_double,
         );
         cairo_fill(self.cairo);
+    }
+
+    unsafe fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, r: f32, g: f32, b: f32, a: f32) {
+        let (width,height) = util::get_xlib_window_size(self.display,self.handle);
+        let xc = width / 2;
+        let yc = height / 2;
+
+        cairo_set_line_width(self.cairo,10.0);
+
+        // draw red lines out from the center of the window
+        cairo_set_source_rgba(self.cairo, r as c_double, g as c_double, b as c_double,a as c_double);
+        cairo_move_to(self.cairo,0.0, 0.0);
+        cairo_line_to(self.cairo, xc as c_double, yc as c_double);
+        cairo_line_to(self.cairo, 0.0, height as c_double);
+        cairo_move_to(self.cairo, xc as c_double, yc as c_double);
+        cairo_line_to(self.cairo, width as c_double, yc as c_double);
+        cairo_stroke(self.cairo);
     }
 }
 

--- a/bly-corefoundation/src/lib.rs
+++ b/bly-corefoundation/src/lib.rs
@@ -11,11 +11,27 @@ pub struct CoreFoundationBackend {
 }
 
 impl Backend for CoreFoundationBackend {
+    unsafe fn begin_draw(&mut self) {
+        todo!()
+    }
+
+    unsafe fn flush(&mut self) {
+        todo!()
+    }
+
+    unsafe fn get_display_size(&mut self) -> (u32, u32) {
+        todo!()
+    }
+
     unsafe fn clear(&mut self, r: f32, g: f32, b: f32, a: f32) {
         
     }
 
     unsafe fn draw_rect(&mut self, left: f32, top: f32, right: f32, bottom: f32, r: f32, g: f32, b: f32, a: f32) {
 
+    }
+
+    unsafe fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, r: f32, g: f32, b: f32, a: f32) {
+        todo!()
     }
 }

--- a/bly-dx2d/src/lib.rs
+++ b/bly-dx2d/src/lib.rs
@@ -70,6 +70,38 @@ impl Backend for Direct2DBackend {
 
         self.target.FillRectangle(&rect1, brush1);
     }
+
+    unsafe fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, r: f32, g: f32, b: f32, a: f32) {
+        let color = D2D1_COLOR_F {
+            r,
+            g,
+            b,
+            a,
+        };
+
+        let properties = D2D1_BRUSH_PROPERTIES {
+            opacity: a,
+            transform: Matrix3x2::identity(),
+        };
+
+        let brush1 = &self.target.CreateSolidColorBrush(&color, &properties).unwrap();
+
+        let props = D2D1_STROKE_STYLE_PROPERTIES {
+            startCap: D2D1_CAP_STYLE_ROUND,
+            endCap: D2D1_CAP_STYLE_TRIANGLE,
+            ..Default::default()
+        };
+
+        let style = unsafe { self.factory.CreateStrokeStyle(&props, &[]).unwrap() };
+
+        self.target.DrawLine(D2D_POINT_2F {
+            x:x1,
+            y:y1,
+        }, D2D_POINT_2F {
+            x: x2,
+            y: y2,
+        }, brush1, stroke, style);
+    }
 }
 
 fn create_target(hwnd:HWND,factory:&ID2D1Factory1) -> (ID2D1HwndRenderTarget,u32,u32) {

--- a/bly/examples/tiles.rs
+++ b/bly/examples/tiles.rs
@@ -42,17 +42,17 @@ fn main() {
             Event::MainEventsCleared => bly.draw(|bdc| {
                 bdc.clear(Color::WhiteGray);
 
-                bdc.draw_rect(20.0, 20.0, 150.0, 150.0, Color::Rgba(1.0, 1.0, 1.0, 1.0));
-                bdc.draw_rect(180.0, 20.0, 150.0, 150.0, Color::Rgba(0.5, 0.5, 0.5, 1.0));
-                bdc.draw_rect(340.0, 20.0, 150.0, 150.0, Color::Rgba(0.0, 0.0, 0.0, 1.0));
-
-                bdc.draw_rect(20.0, 180.0, 150.0, 150.0, Color::Rgba(1.0, 0.0, 0.0, 1.0));
-                bdc.draw_rect(180.0, 180.0, 150.0, 150.0, Color::Rgba(0.0, 1.0, 0.0, 1.0));
-                bdc.draw_rect(340.0, 180.0, 150.0, 150.0, Color::Rgba(0.0, 0.0, 1.0, 1.0));
-
-                bdc.draw_rect(20.0, 340.0, 150.0, 150.0, Color::Rgba(1.0, 1.0, 0.0, 1.0));
-                bdc.draw_rect(180.0, 340.0, 150.0, 150.0, Color::Rgba(0.0, 1.0, 1.0, 1.0));
-                bdc.draw_rect(340.0, 340.0, 150.0, 150.0, Color::Rgba(1.0, 0.0, 1.0, 1.0));
+                // bdc.draw_rect(20.0, 20.0, 150.0, 150.0, Color::Rgba(1.0, 1.0, 1.0, 1.0));
+                // bdc.draw_rect(180.0, 20.0, 150.0, 150.0, Color::Rgba(0.5, 0.5, 0.5, 1.0));
+                // bdc.draw_rect(340.0, 20.0, 150.0, 150.0, Color::Rgba(0.0, 0.0, 0.0, 1.0));
+                //
+                // bdc.draw_rect(20.0, 180.0, 150.0, 150.0, Color::Rgba(1.0, 0.0, 0.0, 1.0));
+                // bdc.draw_rect(180.0, 180.0, 150.0, 150.0, Color::Rgba(0.0, 1.0, 0.0, 1.0));
+                // bdc.draw_rect(340.0, 180.0, 150.0, 150.0, Color::Rgba(0.0, 0.0, 1.0, 1.0));
+                //
+                // bdc.draw_rect(20.0, 340.0, 150.0, 150.0, Color::Rgba(1.0, 1.0, 0.0, 1.0));
+                // bdc.draw_rect(180.0, 340.0, 150.0, 150.0, Color::Rgba(0.0, 1.0, 1.0, 1.0));
+                // bdc.draw_rect(340.0, 340.0, 150.0, 150.0, Color::Rgba(1.0, 0.0, 1.0, 1.0));
 
                 bdc.draw_line(10.0,50.0,500.0,300.0,1.0,Color::Black);
             }),

--- a/bly/examples/tiles.rs
+++ b/bly/examples/tiles.rs
@@ -41,6 +41,7 @@ fn main() {
 
             Event::MainEventsCleared => bly.draw(|bdc| {
                 bdc.clear(Color::WhiteGray);
+
                 bdc.draw_rect(20.0, 20.0, 150.0, 150.0, Color::Rgba(1.0, 1.0, 1.0, 1.0));
                 bdc.draw_rect(180.0, 20.0, 150.0, 150.0, Color::Rgba(0.5, 0.5, 0.5, 1.0));
                 bdc.draw_rect(340.0, 20.0, 150.0, 150.0, Color::Rgba(0.0, 0.0, 0.0, 1.0));
@@ -52,6 +53,8 @@ fn main() {
                 bdc.draw_rect(20.0, 340.0, 150.0, 150.0, Color::Rgba(1.0, 1.0, 0.0, 1.0));
                 bdc.draw_rect(180.0, 340.0, 150.0, 150.0, Color::Rgba(0.0, 1.0, 1.0, 1.0));
                 bdc.draw_rect(340.0, 340.0, 150.0, 150.0, Color::Rgba(1.0, 0.0, 1.0, 1.0));
+
+                bdc.draw_line(10.0,50.0,500.0,300.0,1.0,Color::Black);
             }),
             _ => (),
         }

--- a/bly/src/lib.rs
+++ b/bly/src/lib.rs
@@ -60,6 +60,23 @@ impl Bdc {
             );
         }
     }
+
+    pub fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, color: Color) {
+        unsafe {
+            let vec: Vec4 = color.into();
+            self.backend.draw_line(
+                x1,
+                y1,
+                x2,
+                y2,
+                stroke,
+                vec.0 as f32,
+                vec.1 as f32,
+                vec.2 as f32,
+                vec.3 as f32,
+            );
+        }
+    }
 }
 
 pub struct Bly {


### PR DESCRIPTION
You can call unsafe fn draw_line(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, stroke: f32, r: f32, g: f32, b: f32, a: f32); to draw.